### PR TITLE
mpt: Fix bugs found with the fuzzer

### DIFF
--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -56,7 +56,13 @@ impl Node {
 			Node::Empty => Node::new(nibbles, Node::new_value(value)),
 			Node::Branch(node) => node.insert(nibbles, value),
 			Node::Extension(node) => node.insert(nibbles, value),
-			Node::Value(..) => Node::new_value(value),
+			Node::Value(node) => {
+				if nibbles.is_empty() {
+					Node::new_value(value)
+				} else {
+					BranchNode::new_with_value(node).insert(nibbles, value)
+				}
+			}
 		}
 	}
 
@@ -221,6 +227,11 @@ impl ValueNode {
 		Self { value }
 	}
 	fn get(&self, _nibbles: &[u8]) -> Option<&[u8]> {
+		// if _nibbles.is_empty() {
+		// 	Some(&self.value)
+		// } else {
+		// 	None
+		// }
 		// TODO: Intentional bug to see if fuzzing will catch it
 		Some(&self.value)
 	}

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -177,7 +177,7 @@ impl ExtensionNode {
 	fn insert(self, nibbles: &[u8], value: Vec<u8>) -> Node {
 		let (common, new_nibbles, old_nibbles) = match_paths(nibbles, &self.nibbles);
 		if new_nibbles.is_empty() && old_nibbles.is_empty() {
-			return self.child.insert(nibbles, value);
+			return ExtensionNode::new_node(common, Box::new(self.child.insert(&[], value)));
 		}
 		// Inserting here will alwasy create branch node.
 		// Turn the existing node into that branch node then insert the new value.
@@ -227,13 +227,14 @@ impl ValueNode {
 		Self { value }
 	}
 	fn get(&self, _nibbles: &[u8]) -> Option<&[u8]> {
-		// if _nibbles.is_empty() {
-		// 	Some(&self.value)
-		// } else {
-		// 	None
-		// }
-		// TODO: Intentional bug to see if fuzzing will catch it
-		Some(&self.value)
+		if _nibbles.is_empty() {
+			Some(&self.value)
+		} else {
+			None
+		}
+		// // TODO: Intentional bug to see if fuzzing will catch it.
+		// // It did not b/c I did not fuzz by querying with known missing keys.
+		// Some(&self.value)
 	}
 	fn rlp_bytes(&self, _: &mut HashMap<H256, Vec<u8>>) -> Vec<u8> {
 		encode_bytes(self.value.clone())

--- a/crates/mpt/src/test.rs
+++ b/crates/mpt/src/test.rs
@@ -96,6 +96,18 @@ fn test_mpt_get() {
 }
 
 #[test]
+// Found via fuzzing
+fn test_mpt_empty_overwrite() {
+	let mut mpt = MPT::default();
+	mpt.insert(vec![], vec![]);
+	mpt.insert(vec![2], vec![0]);
+	mpt.insert(vec![], vec![]);
+
+	assert_eq!(mpt.get(vec![]), Some(vec![].as_slice()));
+	assert_eq!(mpt.get(vec![2]), Some(vec![0].as_slice()));
+}
+
+#[test]
 fn test_mpt_overwrite() {
 	let mut mpt = MPT::default();
 	let inputs = vec![

--- a/crates/mpt/src/test.rs
+++ b/crates/mpt/src/test.rs
@@ -108,6 +108,18 @@ fn test_mpt_empty_overwrite() {
 }
 
 #[test]
+// Found via fuzzing
+fn test_mpt_overwrite_value_of_extension_node() {
+	let mut mpt = MPT::default();
+	mpt.insert(vec![0], vec![]);
+	mpt.insert(vec![0], vec![0]);
+	mpt.insert(vec![], vec![]);
+
+	assert_eq!(mpt.get(vec![]), Some(vec![].as_slice()));
+	assert_eq!(mpt.get(vec![0]), Some(vec![0].as_slice()));
+}
+
+#[test]
 fn test_mpt_overwrite() {
 	let mut mpt = MPT::default();
 	let inputs = vec![
@@ -123,6 +135,19 @@ fn test_mpt_overwrite() {
 	}
 	assert_eq!(mpt.get("doge".into()), Some("moon".as_bytes()));
 	assert_eq!(mpt.get("horse".into()), Some("mare".as_bytes()));
+}
+
+#[test]
+fn test_mpt_prefix_get() {
+	let mut mpt = MPT::default();
+	let inputs = vec![("do", "verb"), ("dog", "puppy"), ("doge", "coin"), ("horse", "stallion")];
+	for (k, v) in inputs.iter() {
+		mpt.insert(k.as_bytes().to_vec(), v.as_bytes().to_vec());
+	}
+	assert_eq!(mpt.get("d".into()), None);
+	assert_eq!(mpt.get("dodo".into()), None);
+	assert_eq!(mpt.get("doges".into()), None);
+	assert_eq!(mpt.get("horses".into()), None);
 }
 
 // Test MPT from https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/


### PR DESCRIPTION
This fixes two bugs found with the fuzzer. It is now able to run the
fuzzer for a significant period of time without finding bugs. In
addition, this fixes one known bug that I was attempting to find via
fuzzing, but is not able to be found with the test setup.

This adds regression tests for all of the found bugs.
