### PR TITLE
Use custom types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ name = "core"
 version = "0.1.0"
 dependencies = [
  "ethers-core 1.0.2",
+ "hex-literal 0.4.1",
  "reth-primitives",
 ]
 
@@ -449,6 +450,7 @@ dependencies = [
  "ethers-core 1.0.2",
  "eyre",
  "flate2",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]
@@ -1402,6 +1404,7 @@ version = "0.1.0"
 dependencies = [
  "core",
  "hex",
+ "hex-literal 0.4.1",
  "reth-primitives",
  "reth-rlp",
 ]
@@ -1954,6 +1957,7 @@ dependencies = [
  "derivation",
  "dotenv",
  "eyre",
+ "hex-literal 0.4.1",
  "mpt",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 ethers-core = "1.0.2"
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", features = [] }
+hex-literal = "0.4.1"

--- a/crates/core/src/id.rs
+++ b/crates/core/src/id.rs
@@ -1,6 +1,6 @@
 use crate::types::*;
 
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash)]
 pub struct BlockID {
 	pub hash: Hash,
 	pub number: u64,
@@ -39,7 +39,7 @@ pub struct L2BlockRef {
 impl From<Header> for BlockID {
 	fn from(h: Header) -> Self {
 		Self {
-			hash: h.hash_slow(),
+			hash: h.hash_slow().into(),
 			number: h.number,
 		}
 	}
@@ -57,9 +57,9 @@ impl From<L1BlockRef> for BlockID {
 impl From<Header> for L1BlockRef {
 	fn from(h: Header) -> Self {
 		Self {
-			hash: h.hash_slow(),
+			hash: h.hash_slow().into(),
 			number: h.number,
-			parent_hash: h.parent_hash,
+			parent_hash: h.parent_hash.into(),
 			time: h.timestamp,
 		}
 	}

--- a/crates/derivation/Cargo.toml
+++ b/crates/derivation/Cargo.toml
@@ -8,3 +8,4 @@ core = {path = "../core"}
 ethers-core = "1.0.2"
 eyre = "0.6.8"
 flate2 = "1.0.25"
+hex-literal = "0.4.1"

--- a/crates/derivation/src/derivation.rs
+++ b/crates/derivation/src/derivation.rs
@@ -6,11 +6,10 @@ use super::read_adapter::ReadAdpater;
 
 use core::prelude::*;
 
-use core::types::{Address, Receipt, Transaction};
+use core::types::{Receipt, Transaction};
 use ethers_core::utils::rlp::{decode, Rlp};
 use flate2::read::ZlibDecoder;
 use std::io::Read;
-use std::str::FromStr;
 
 fn decompress(r: impl Read) -> Vec<u8> {
 	let mut decomp = ZlibDecoder::new(r);
@@ -54,7 +53,7 @@ pub struct Derivation {
 impl Derivation {
 	pub fn load_l1_data(&mut self, l1_block: L1BlockRef, transactions: Vec<Transaction>, _receipts: Vec<Receipt>) {
 		// TODO: Create system config from the receipts
-		let batcher_address = Address::from_str("0x7431310e026B69BFC676C0013E12A1A11411EEc9").unwrap();
+		let batcher_address = core::address_literal!("7431310e026B69BFC676C0013E12A1A11411EEc9");
 
 		let batches = transactions
 			.into_iter()

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -10,4 +10,4 @@ core = {path = "../core"}
 reth-rlp = { git = "https://github.com/paradigmxyz/reth" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth" }
 hex = "0.4.3"
-
+hex-literal = "0.4.1"

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -1,6 +1,5 @@
 use crate::misc::*;
-use core::types::Hash;
-use reth_primitives::keccak256;
+use core::types::{keccak, Hash};
 use std::{collections::HashMap, fmt::Debug};
 
 mod display;
@@ -16,7 +15,7 @@ pub struct MPT {
 
 impl MPT {
 	pub fn hash(&mut self) -> Hash {
-		keccak256(self.root.rlp_bytes(&mut self.db))
+		keccak(self.root.rlp_bytes(&mut self.db))
 	}
 
 	pub fn insert(&mut self, k: Vec<u8>, v: Vec<u8>) {

--- a/crates/mpt/src/misc.rs
+++ b/crates/mpt/src/misc.rs
@@ -1,5 +1,5 @@
-use core::types::Hash;
-use reth_primitives::{keccak256, Bytes};
+use core::types::{keccak, Hash};
+use reth_primitives::Bytes;
 use reth_rlp::Encodable;
 use std::{collections::HashMap, fmt::Debug, iter::zip};
 
@@ -33,7 +33,7 @@ pub fn mpt_hash(x: &[u8], db: &mut HashMap<Hash, Vec<u8>>) -> RLPEncodeableWrapp
 	if x.len() < 32 {
 		RLPEncodeableWrapper::Raw(x.to_vec())
 	} else {
-		let h = keccak256(x);
+		let h = keccak(x);
 		db.insert(h, x.to_vec());
 		RLPEncodeableWrapper::Bytes(h.to_vec())
 	}

--- a/crates/mpt/src/test.rs
+++ b/crates/mpt/src/test.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use std::str::FromStr;
+use core::hash_literal;
 
 struct NibblesCompactTestCase {
 	nibbles: Vec<u8>,
@@ -75,7 +75,7 @@ fn test_nibbles_compact_conversions() {
 fn test_empty_root_hash() {
 	let mut mpt = MPT::default();
 	let hash = mpt.hash();
-	let expected = Hash::from_str("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421").unwrap();
+	let expected = hash_literal!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
 	assert_eq!(hash, expected);
 }
 
@@ -191,21 +191,21 @@ fn test_mpt_hash() {
 
 	mpt.insert("do".into(), "verb".into());
 	let hash = mpt.hash();
-	let expected_hash = Hash::from_str("0x014f07ed95e2e028804d915e0dbd4ed451e394e1acfd29e463c11a060b2ddef7").unwrap();
+	let expected_hash: Hash = hash_literal!("014f07ed95e2e028804d915e0dbd4ed451e394e1acfd29e463c11a060b2ddef7");
 	assert_eq!(expected_hash, hash);
 
 	mpt.insert("dog".into(), "puppy".into());
 	let hash = mpt.hash();
-	let expected_hash = Hash::from_str("0x779db3986dd4f38416bfde49750ef7b13c6ecb3e2221620bcad9267e94604d36").unwrap();
+	let expected_hash: Hash = hash_literal!("779db3986dd4f38416bfde49750ef7b13c6ecb3e2221620bcad9267e94604d36");
 	assert_eq!(expected_hash, hash);
 
 	mpt.insert("doge".into(), "coin".into());
 	let hash = mpt.hash();
-	let expected_hash = Hash::from_str("0xef7b2fe20f5d2c30c46ad4d83c39811bcbf1721aef2e805c0e107947320888b6").unwrap();
+	let expected_hash: Hash = hash_literal!("ef7b2fe20f5d2c30c46ad4d83c39811bcbf1721aef2e805c0e107947320888b6");
 	assert_eq!(expected_hash, hash);
 
 	mpt.insert("horse".into(), "stallion".into());
 	let hash = mpt.hash();
-	let expected_hash = Hash::from_str("0x5991bb8c6514148a29db676a14ac506cd2cd5775ace63c30a4fe457715e9ac84").unwrap();
+	let expected_hash: Hash = hash_literal!("5991bb8c6514148a29db676a14ac506cd2cd5775ace63c30a4fe457715e9ac84");
 	assert_eq!(expected_hash, hash);
 }

--- a/rnode/Cargo.toml
+++ b/rnode/Cargo.toml
@@ -12,3 +12,4 @@ mpt = {path = "../crates/mpt"}
 
 eyre = "0.6.8"
 dotenv = "0.15.0"
+hex-literal = "0.4.1"

--- a/rnode/src/main.rs
+++ b/rnode/src/main.rs
@@ -1,9 +1,8 @@
 use dotenv::dotenv;
 use eyre::Result;
-use std::str::FromStr;
 
 use client::prelude::*;
-use core::types::Hash;
+use core::{hash_literal, types::Hash};
 use derivation::derivation::Derivation;
 
 fn main() -> Result<()> {
@@ -12,11 +11,11 @@ fn main() -> Result<()> {
 
 	let provider = std::env::var("RPC")?;
 	let mut provider = Client::new(&provider)?;
-	let hash = Hash::from_str("0x20ffc57ae0c607d4b612662251738b01c44f8a9a42a1da89a881a56a5fad426e")?;
+	let hash = hash_literal!("20ffc57ae0c607d4b612662251738b01c44f8a9a42a1da89a881a56a5fad426e");
 
 	let header = provider.get_header(hash)?;
-	let transactions = provider.get_transactions_by_root(header.transactions_root)?;
-	let receipts = provider.get_receipts_by_root(header.receipts_root)?;
+	let transactions = provider.get_transactions_by_root(header.transactions_root.into())?;
+	let receipts = provider.get_receipts_by_root(header.receipts_root.into())?;
 
 	let mut derivation = Derivation::default();
 	derivation.load_l1_data(header.into(), transactions, receipts);


### PR DESCRIPTION
This migrates to my own Hash, Address, and ChannelID types. I have not completed the migration off of upstream types, but it is in progress.